### PR TITLE
Added docs requirements.txt and readthedocs.yml file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ sphinx:
 
 # Optionally build your docs in additional formats such as PDF
 formats:
-  - html
+  - htmlzip
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,24 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - html
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,8 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF
 formats:
   - htmlzip
+  - pdf
+  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,6 @@ sphinx:
 formats:
   - htmlzip
   - pdf
-  - epub
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/docs/quickstartcomps.rst
+++ b/docs/quickstartcomps.rst
@@ -5,6 +5,10 @@ Running |VT| from |COMPS_s|
 This page gives a quick overview of how to run |VT| from within the |COMPS_s|
 system.
 
+.. note::
+
+    To access and use |COMPS_s| you must receive approval and credentials from |IDM_s|. Send your request to support@idmod.org.
+
 To use |VT| this way, you'll need to create or otherwise have access to a
 spatial simulation, which is to say, a simulation with multiple nodes that have
 latitude/longitude geospatial locations.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+sphinx-rtd-theme~=0.4.3
+sphinxcontrib-napoleon~=0.7
+sphinx~=2.4.4
+plantweb~=1.2.1
+numpydoc~=1.0.0


### PR DESCRIPTION
The requirements and YAML config files allow the docs build to occur on the RTD servers with each commit to master. Docs associated with tagged releases have been tested and work correctly if you want to add them going forward. I plan to add weighting to search results later. 